### PR TITLE
Bug fix with format!()

### DIFF
--- a/ripgen_lib/src/dnsgen/swap.rs
+++ b/ripgen_lib/src/dnsgen/swap.rs
@@ -22,7 +22,7 @@ pub fn swap_word_transform<'domain>(
                 .filter(move |sub_word| **sub_word != word_clone)
                 .map(move |sub_word| {
                     let replaced_subdomain = subdomain_replace.replace(word, sub_word);
-                    format!("{replaced_subdomain}.{root_string}")
+                    format!("{}.{}",replaced_subdomain,root_string)
                 })
         })
 }


### PR DESCRIPTION
Fix the following build errors:

```rust
error: there is no argument named `replaced_subdomain`
  --> /root/.cargo/registry/src/github.com-1ecc6299db9ec823/ripgen_lib-0.1.4/src/dnsgen/swap.rs:25:30
   |
25 |                     format!("{replaced_subdomain}.{root_string}")
   |                              ^^^^^^^^^^^^^^^^^^^^

error: there is no argument named `root_string`
  --> /root/.cargo/registry/src/github.com-1ecc6299db9ec823/ripgen_lib-0.1.4/src/dnsgen/swap.rs:25:51
   |
25 |                     format!("{replaced_subdomain}.{root_string}")
```