### PR TITLE
Update Cargo.toml

### DIFF
--- a/ripgen_lib/Cargo.toml
+++ b/ripgen_lib/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/resyncgg/ripgen"
 
 [dependencies]
 thiserror = "1"
-addr = "0"
+addr = "0.15"
 fxhash = "0.2.1"
 regex = { version = "1", optional = true }
 lazy_static = { version = "1", optional = true }


### PR DESCRIPTION
Mentioning "0" would mean cargo would pick the latest dependency which is versioned "0.*" which would include versions incompatible with the one that this crate was written with and may break your create.