### PR TITLE
Docs: Update readme instructions for building ripgen on alpine

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,8 @@ sudo pacman -S base-devel
 sudo yum install gcc
 ```
 
+### Alpine
+```
+apk add build-base --no-cache
+```
+


### PR DESCRIPTION
Ran into troubleshooting problems installing ripgen on alpine (commonly used in docker builds). Realized it requires `build-base` package. Pull request reflects this requirement in docs for clarity and guiding future user installations. 